### PR TITLE
Format price in notes with two decimal places

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -248,7 +248,7 @@ async function updateMonarchTransactions() {
   for (const data of matches) {
     const itemString = data.amazon.items
       .map(item => {
-        return item.title + ' - $' + item.price;
+        return item.title + ' - $' + item.price.toFixed(2);
       })
       .join('\n\n')
       .trim();


### PR DESCRIPTION
This pull request uses `Number.prototype.toFixed(2)` to format prices in notes as "$1.70" rather than "$1.7"