### PR TITLE
Capture gift card payment as a transaction

### DIFF
--- a/src/shared/api/amazonApi.ts
+++ b/src/shared/api/amazonApi.ts
@@ -148,7 +148,10 @@ function orderListFromPage($: CheerioAPI): Order[] {
   const orders: Order[] = [];
   $('.order-card').each((_, el) => {
     try {
-      const id = $(el).find('.yohtmlc-order-id')?.text().trim().replace('\n', '').split('#')[1].trim();
+      const id = $(el)
+        .find('a[href*="orderID="]')
+        ?.attr('href')
+        ?.replace(/.*orderID=([^&#]+).*/, '$1');
       if (id) {
         const date = $(el).find('.order-info .value')?.first().text().trim();
         orders.push({

--- a/src/shared/api/matchUtil.ts
+++ b/src/shared/api/matchUtil.ts
@@ -14,16 +14,18 @@ export function matchTransactions(
   override: boolean,
 ): MatchedTransaction[] {
   const orderTransactions = orders.flatMap(order => {
-    return order.transactions.map(transaction => {
-      return {
-        items: transaction.items,
-        refund: transaction.refund,
-        amount: transaction.refund ? transaction.amount : transaction.amount * -1,
-        date: transaction.date,
-        used: false,
-        id: order.id,
-      };
-    });
+    return (
+      order.transactions?.map(transaction => {
+        return {
+          items: transaction.items,
+          refund: transaction.refund,
+          amount: transaction.refund ? transaction.amount : transaction.amount * -1,
+          date: transaction.date,
+          used: false,
+          id: order.id,
+        };
+      }) ?? []
+    );
   });
 
   // find monarch transactions that match amazon orders. don't allow duplicates


### PR DESCRIPTION
Adds support for matching Monarch transactions for the portion of an order paid with a gift card. In the past I paid for most Amazon purchases with discounted gift cards so the majority of my Amazon transactions in Monarch are not from credit card statements but rather were manually keyed in. On the order details page this amount is identified by "Gift Card Amount." 

Additionally captures the order date from the orders list because it is more accessible there than on the detail page. The order date is required for recording gift card transactions and will also be required for future support of orders that do not show the "Transactions" dropdown (see #7).

As a test run I tried to sync 39 Amazon transactions from 2013 that previously showed zero matches in Monarch. After making these changes, 27 of them matched up. I never kept perfect track of gift card transactions so that was a good result.