### PR TITLE
Capture order ID from details link

### DIFF
--- a/src/shared/api/amazonApi.ts
+++ b/src/shared/api/amazonApi.ts
@@ -147,7 +147,10 @@ function orderListFromPage($: CheerioAPI): string[] {
   const orders: string[] = [];
   $('.order-card').each((_, el) => {
     try {
-      const order = $(el).find('.yohtmlc-order-id')?.text().trim().replace('\n', '').split('#')[1].trim();
+      const order = $(el)
+        .find('a[href*="orderID="]')
+        ?.attr('href')
+        ?.replace(/.*orderID=([^&#]+).*/, '$1');
       if (order) {
         orders.push(order);
       }


### PR DESCRIPTION
Retrieves the orderID from links to the order inside each order card rather than from the text displayed in the card header. May fix #6 unless the inability to split on "#" in "Order # xxx-xxxxxx-xxxxxx" is just a symptom of more significant layout differences for some Amazon customers.