### PR TITLE
Update index.ts

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -248,7 +248,11 @@ async function updateMonarchTransactions() {
   for (const data of matches) {
     const itemString = data.amazon.items
       .map(item => {
-        return item.title + ' - $' + item.price.toFixed(2);
+        if (item.price) {
+          return item.title + ' - $' + item.price.toFixed(2);
+        } else {
+          return item.title;
+        }
       })
       .join('\n\n')
       .trim();


### PR DESCRIPTION
Setting the Monarch notes can crash if the Amazon item doesn't have a price. It crashed for me. I didn't go through the code to understand why the price isn't set.  