### PR TITLE
Log all debug messages using console.log

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -67,6 +67,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
           }
         } catch (ex) {
           await appStorage.patch({ monarchStatus: AuthStatus.Failure });
+          debugLog(ex);
         }
       }
     }

--- a/src/shared/storages/debugStorage.ts
+++ b/src/shared/storages/debugStorage.ts
@@ -27,6 +27,7 @@ export async function debugLog(val: unknown) {
   await debugStorage.set(state => ({
     logs: (state?.logs ?? []).concat([stringValue]),
   }));
+  console.log(val);
 }
 
 export default debugStorage;


### PR DESCRIPTION
Having to go to Options > Download debug logs isn't the most convenient way to access logs by a plugin developer. Let's also have them in the extension's Dev Tools.