### PR TITLE
[work in progress] Support for Walmart

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -13,6 +13,8 @@ const manifest = {
   host_permissions: [
     'https://amazon.com/*',
     'https://www.amazon.com/*',
+    'https://walmart.com/*',
+    'https://www.walmart.com/*',
     'https://app.monarchmoney.com/*',
     'https://api.monarchmoney.com/*',
   ],

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -67,6 +67,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
           }
         } catch (ex) {
           await appStorage.patch({ monarchStatus: AuthStatus.Failure });
+          debugLog(ex);
         }
       }
     }

--- a/src/pages/popup/Options.tsx
+++ b/src/pages/popup/Options.tsx
@@ -32,7 +32,16 @@ export function Options() {
 
   useEffect(() => {
     if (!options) {
-      appStorage.patch({ options: { overrideTransactions: false, syncEnabled: false, amazonMerchant: 'Amazon' } });
+      appStorage.patch({
+        options: {
+          overrideTransactions: false,
+          syncEnabled: false,
+          amazonMerchant: 'Amazon',
+          walmartMerchant: 'Walmart',
+          transactionMatchingWindowInDays: 7,
+          maxPages: Infinity,
+        },
+      });
     }
   }, [options]);
 
@@ -42,20 +51,90 @@ export function Options() {
 
   return (
     <div className="m-3">
-      <div className="mb-2 block">
-        <Label htmlFor="countries" value="What merchant is Amazon in Monarch?" />
+      <div className="flex flex-col mb-2">
+        <div className="mb-1 block">
+          <Label htmlFor="amazonMerchant" value="What merchant is Amazon in Monarch?" />
+        </div>
+        <TextInput
+          defaultValue={options?.amazonMerchant}
+          className="pb-3"
+          type="text"
+          id="amazonMerchant"
+          placeholder="Amazon merchant"
+          onChange={element => {
+            appStorage.patch({ options: { ...options, amazonMerchant: element.target.value } });
+          }}
+        />
       </div>
-      <TextInput
-        defaultValue={options?.amazonMerchant}
-        className="pb-3"
-        type="text"
-        id="merchant"
-        placeholder="Amazon merchant"
-        onChange={element => {
-          appStorage.patch({ options: { ...options, amazonMerchant: element.target.value } });
-        }}
-      />
-      <div className="flex flex-col">
+      <div className="flex flex-col mb-2">
+        <div className="mb-1 block">
+          <Label htmlFor="walmartMerchant" value="What merchant is Walmart in Monarch?" />
+        </div>
+        <TextInput
+          defaultValue={options?.walmartMerchant}
+          className="pb-3"
+          type="text"
+          id="walmartMerchant"
+          placeholder="Walmart merchant"
+          onChange={element => {
+            appStorage.patch({ options: { ...options, walmartMerchant: element.target.value } });
+          }}
+        />
+      </div>
+      <div className="flex flex-col mb-3">
+        <div className="mb-1 block">
+          <Label htmlFor="transactionMatchingWindowInDays" value="Transaction matching window in days" />
+        </div>
+        <TextInput
+          defaultValue={options?.transactionMatchingWindowInDays}
+          className="pb-3"
+          type="number"
+          id="transactionMatchingWindowInDays"
+          placeholder="Transaction matching window in days"
+          onChange={element => {
+            appStorage.patch({
+              options: { ...options, transactionMatchingWindowInDays: parseInt(element.target.value) },
+            });
+          }}
+        />
+        <span className="mt-1 text-gray-500 text-xs font-normal">
+          This is the number of days around the transaction date to look for a matching transaction in Monarch. Increase
+          if you have an issue with matching Subscribe & Save transactions.
+        </span>
+      </div>
+      <div className="flex flex-col mb-3">
+        <div className="mb-1 block">
+          <Label htmlFor="maxPages" value="Maximum number of order pages" />
+        </div>
+        <TextInput
+          defaultValue={
+            options?.maxPages && isFinite(options.maxPages) ? (options.maxPages === 0 ? '' : options.maxPages) : ''
+          }
+          className="pb-3"
+          type="text"
+          pattern="^\d*$"
+          id="maxPages"
+          placeholder="No limit"
+          onChange={element => {
+            const value = element.target.value;
+            let newValue;
+            if (value === '') {
+              newValue = 0;
+            } else {
+              newValue = parseInt(value);
+              if (isNaN(newValue)) {
+                newValue = options.maxPages;
+              }
+            }
+            appStorage.patch({ options: { ...options, maxPages: newValue } });
+          }}
+        />
+        <span className="mt-1 text-gray-500 text-xs font-normal">
+          This is the maximum number of order pages to look through. Useful for troubleshooting the time it takes to go
+          through the entire sync cycle. Leave empty for no limit.
+        </span>
+      </div>
+      <div className="flex flex-col mb-3">
         <ToggleSwitch
           checked={options.overrideTransactions}
           label="Override existing notes"

--- a/src/pages/popup/Options.tsx
+++ b/src/pages/popup/Options.tsx
@@ -1,5 +1,5 @@
 import useStorage from '@root/src/shared/hooks/useStorage';
-import appStorage from '@root/src/shared/storages/appStorage';
+import appStorage, { AuthStatus } from '@root/src/shared/storages/appStorage';
 import debugStorage from '@root/src/shared/storages/debugStorage';
 import { Label, TextInput, ToggleSwitch } from 'flowbite-react';
 import { useCallback, useEffect } from 'react';
@@ -17,6 +17,18 @@ export function Options() {
       filename: 'error-dump.txt',
     });
   }, [logs]);
+
+  const resetMonarchStatus = useCallback(async () => {
+    await appStorage.patch({
+      monarchKey: undefined,
+      lastMonarchAuth: undefined,
+      monarchStatus: AuthStatus.NotLoggedIn,
+    });
+  }, []);
+
+  const resetAmazonStatus = useCallback(async () => {
+    await appStorage.patch({ amazonStatus: AuthStatus.NotLoggedIn });
+  }, []);
 
   useEffect(() => {
     if (!options) {
@@ -56,6 +68,7 @@ export function Options() {
           name if it does not already match.
         </span>
       </div>
+
       {logs && logs.length > 0 && (
         <div className="mt-2">
           <button className="btn btn-primary" onClick={downloadDebugLog}>
@@ -63,6 +76,21 @@ export function Options() {
           </button>
         </div>
       )}
+
+      <div className="mt-2">
+        <button className="btn btn-primary" onClick={resetMonarchStatus}>
+          Reset Monarch connection status
+        </button>
+        <span className="mt-1 text-gray-500 text-xs font-normal">
+          If GraphQL requests to Monarch API fail, the extension cached an expired token. You must log out from Monarch,
+          reset the connection status using this button, and log in again.
+        </span>
+      </div>
+      <div className="mt-2">
+        <button className="btn btn-primary" onClick={resetAmazonStatus}>
+          Reset Amazon connection status
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/pages/popup/components/ProgressIndicator.tsx
+++ b/src/pages/popup/components/ProgressIndicator.tsx
@@ -23,11 +23,7 @@ export function ProgressIndicator({ progress }: { progress: ProgressState }) {
       return;
     }
 
-    const matches = matchTransactions(
-      transactions.transactions,
-      transactions.orders,
-      appData.options.overrideTransactions,
-    );
+    const matches = matchTransactions(transactions.transactions, transactions.orders, appData.options);
     const contents = matches.map(match => {
       return {
         amazonOrderId: match.amazon.id,

--- a/src/shared/api/amazonApi.ts
+++ b/src/shared/api/amazonApi.ts
@@ -147,7 +147,7 @@ async function processOrders(year: number | undefined, page: number) {
 
 function orderListFromPage($: CheerioAPI): Order[] {
   const orders: Order[] = [];
-  $('.order-card').each((_, el) => {
+  $('.js-order-card').each((_, el) => {
     try {
       const id = $(el)
         .find('a[href*="orderID="]')

--- a/src/shared/api/monarchApi.ts
+++ b/src/shared/api/monarchApi.ts
@@ -3,6 +3,7 @@ export type Transaction = {
   amount: number;
   date: string;
   notes: string;
+  merchant: string;
 };
 
 export async function updateMonarchTransaction(authKey: string, id: string, note: string) {
@@ -69,6 +70,9 @@ export async function getTransactions(
             pending
             date
             notes
+            merchant {
+              name
+            }
           }
         }
       }
@@ -76,7 +80,14 @@ export async function getTransactions(
   };
 
   const result = await graphQLRequest(authKey, body);
-  return result.data.allTransactions.results;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return result.data.allTransactions.results.map((transaction: any) => ({
+    id: transaction.id,
+    amount: transaction.amount,
+    date: transaction.date,
+    notes: transaction.notes,
+    merchant: transaction.merchant.name,
+  }));
 }
 
 async function graphQLRequest(authKey: string, body: unknown) {

--- a/src/shared/api/walmartApi.ts
+++ b/src/shared/api/walmartApi.ts
@@ -1,0 +1,242 @@
+import { ProgressPhase, ProgressState } from '../storages/progressStorage';
+import { load } from 'cheerio';
+import type { CheerioAPI } from 'cheerio';
+import * as Throttle from 'promise-parallel-throttle';
+import { debugLog } from '../storages/debugStorage';
+import { AuthStatus } from '../storages/appStorage';
+import { Order, Item, OrderTransaction } from './amazonApi';
+import { Provider } from '@root/src/pages/background';
+
+const ORDER_PAGES_URL = 'https://www.walmart.com/orders';
+const ORDER_DETAILS_URL = 'https://www.walmart.com/orders/{orderID}?storePurchase={storePurchase}';
+
+export type WalmartInfo = {
+  status: AuthStatus;
+  startingYear?: number;
+};
+
+export async function checkWalmartAuth(): Promise<WalmartInfo> {
+  try {
+    debugLog('Checking Walmart auth');
+    const res = await fetch(ORDER_PAGES_URL);
+    await debugLog('Got Walmart auth response' + res.status);
+    const text = await res.text();
+    const $ = load(text);
+
+    const signIn = $('.mw3:contains("Sign In")');
+
+    if (signIn.length > 0) {
+      await debugLog('Walmart auth failed');
+      return {
+        status: AuthStatus.NotLoggedIn,
+      };
+    }
+
+    const yearOptions: string[] = [];
+    $('#time-filter')
+      .find('option')
+      .each((_, el) => {
+        if ($(el).attr('value')?.includes('year')) {
+          yearOptions.push(el.attribs.value?.trim().replace('year-', ''));
+        }
+      });
+    // find the lowest year
+    const lowestYear = Math.min(...yearOptions.map(x => parseInt(x)));
+
+    await debugLog('Walmart auth success');
+    return {
+      status: AuthStatus.Success,
+      startingYear: lowestYear,
+    };
+  } catch (e) {
+    await debugLog('Walmart auth failed with error: ' + e);
+    return {
+      status: AuthStatus.Failure,
+    };
+  }
+}
+
+export async function fetchOrders(
+  year: number | undefined,
+  maxPages: number | undefined,
+  onProgress: (progress: ProgressState) => void,
+): Promise<Order[]> {
+  let url = ORDER_PAGES_URL;
+  if (year) {
+    url += `?timeFilter=year-${year}`;
+  }
+  await debugLog('Fetching orders from ' + url);
+  const res = await fetch(url);
+  await debugLog('Got orders response ' + res.status);
+  const text = await res.text();
+  const $ = load(text);
+
+  // Walmart doesn't have a paginator, so we can't determine the number of pages. We're limited to 5 orders on the first page.
+  // We could try obtaining a cursor and fetching orders that way.
+  let endPage = 1;
+
+  if (maxPages && maxPages < endPage) {
+    endPage = maxPages;
+  }
+
+  onProgress({ phase: ProgressPhase.WalmartPageScan, total: endPage, complete: 0 });
+
+  let orders = orderListFromPage($);
+  await debugLog('Found ' + orders.length + ' orders');
+
+  onProgress({ phase: ProgressPhase.WalmartPageScan, total: endPage, complete: 1 });
+
+  for (let i = 2; i <= endPage; i++) {
+    const ordersPage = await processOrders(year, i);
+    orders = orders.concat(ordersPage);
+    onProgress({ phase: ProgressPhase.WalmartPageScan, total: endPage, complete: i });
+  }
+
+  const allOrders: Order[] = [];
+
+  const processOrder = async (order: Order) => {
+    try {
+      const orderData = await fetchOrderTransactions(order);
+      if (orderData) {
+        allOrders.push(orderData);
+      }
+    } catch (e: unknown) {
+      await debugLog(e);
+    }
+
+    onProgress({ phase: ProgressPhase.WalmartOrderDownload, total: orders.length, complete: allOrders.length });
+  };
+
+  await Throttle.all(orders.map(order => () => processOrder(order)));
+
+  return allOrders;
+}
+
+async function processOrders(year: number | undefined, page: number) {
+  const index = (page - 1) * 10;
+  let url = ORDER_PAGES_URL + '?startIndex=' + index;
+  if (year) {
+    url += `&timeFilter=year-${year}`;
+  }
+  await debugLog('Fetching orders from ' + url);
+  const res = await fetch(url);
+  await debugLog('Got orders response ' + res.status + ' for page ' + page);
+  const text = await res.text();
+  const $ = load(text);
+  return orderListFromPage($);
+}
+
+function orderListFromPage($: CheerioAPI): Order[] {
+  const orders: Order[] = [];
+
+  $('[data-testid^="orderGroup-"]').each((_, el) => {
+    try {
+      const returnLink = $(el).find('a[link-identifier="Start a return"]')?.attr('href');
+      const id = returnLink?.replace(/.*orders\/([^/]+)\/.*/, '$1');
+      const walmartStorePurchase = returnLink?.includes('orderSource=STORE');
+
+      if (!id) {
+        debugLog('No order ID found in orderGroup-* element');
+        return;
+      }
+
+      const dateText = $(el).find('h3').text().trim();
+      const dateMatch = dateText.match(/(\w+ \d{2}, \d{4}) purchase/);
+      const date = dateMatch ? dateMatch[1] : '';
+
+      orders.push({
+        id,
+        date,
+        provider: Provider.Walmart,
+        walmartStorePurchase,
+      });
+    } catch (e: unknown) {
+      debugLog(e);
+    }
+  });
+
+  // Add a dummy order with a refund for testing
+  // orders.push({
+  //   id: '200010009468360',
+  //   date: 'Jun 29, 2022',  // Use the appropriate date
+  //   type: OrderType.Walmart,
+  //   walmartStorePurchase: false,  // Since it's a non-store purchase
+  // });
+
+  return orders;
+}
+
+async function fetchOrderTransactions(order: Order): Promise<Order> {
+  const orderUrl = ORDER_DETAILS_URL.replace('{orderID}', order.id).replace(
+    '{storePurchase}',
+    order.walmartStorePurchase ? 'true' : 'false',
+  );
+
+  await debugLog('Fetching order ' + order.id + ' from ' + orderUrl);
+  const res = await fetch(orderUrl);
+  await debugLog('Got order response ' + res.status + ' for order ' + order.id);
+  const text = await res.text();
+  const $ = load(text);
+
+  const items: Item[] = [];
+
+  // Parse items in all sections
+  $('[data-testid="itemtile-stack"]').each((_, el) => {
+    const itemTitle = $(el).find('[data-testid="productName"]').first()?.text()?.trim();
+    const itemPriceText = $(el).find('.column3 .f5.b.black.tr').first()?.text()?.trim();
+    const itemPrice = itemPriceText ? parseFloat(itemPriceText.replace(/[^0-9.-]+/g, '')) : 0;
+    const isRefunded = $(el)
+      .closest('[data-testid^="category-accordion"]')
+      .find('[data-testid="category-label"]')
+      .text()
+      .includes('Refunded');
+
+    if (itemTitle) {
+      items.push({
+        provider: Provider.Walmart,
+        orderId: order.id,
+        title: itemTitle,
+        price: itemPrice,
+        refunded: isRefunded,
+      });
+    }
+
+    debugLog(`Found ${isRefunded ? 'refunded' : 'fulfilled'} item for order ${order.id}: ${itemTitle} - $${itemPrice}`);
+  });
+
+  debugLog(`Found ${items.length} items for order ${order.id}`);
+
+  const transactions: OrderTransaction[] = [];
+
+  // Parse order transactions
+  $('[data-testid^="orderGroup-"], .print-bill-body').each((_, el) => {
+    const dateText = $(el).find('h1.print-bill-date').text().trim();
+    const dateMatch = dateText.match(/(\w+ \d{2}, \d{4}) (order|purchase)/);
+    const date = dateMatch ? dateMatch[1] : '';
+
+    const amountText = $(el).find('.bill-order-total-payment h2').last().text().trim();
+    const amount = amountText ? parseFloat(amountText.replace(/[^0-9.-]+/g, '')) : 0;
+
+    const refund = $(el).find('[data-testid="category-label"]').text().includes('Refunded');
+
+    transactions.push({
+      id: order.id,
+      provider: Provider.Walmart,
+      date,
+      amount,
+      refund,
+      items: items.filter(item => item.refunded === refund),
+    });
+
+    debugLog(
+      `Found transaction for order ${order.id} with date ${date}, amount ${amount}, refund ${refund}, and ${items.length} items`,
+    );
+  });
+
+  debugLog('Found ' + transactions.length + ' transactions for order ' + order.id);
+
+  return {
+    ...order,
+    transactions,
+  };
+}

--- a/src/shared/storages/appStorage.ts
+++ b/src/shared/storages/appStorage.ts
@@ -15,9 +15,9 @@ export enum AuthStatus {
 
 export enum FailureReason {
   Unknown = 'unknown',
-  NoAmazonOrders = 'noAmazonOrders',
-  NoAmazonAuth = 'noAmazonAuth',
-  AmazonError = 'amazonError',
+  NoProviderOrders = 'noAmazonOrders',
+  NoProviderAuth = 'noProviderAuth',
+  ProviderError = 'amazonError',
   NoMonarchAuth = 'noMonarchAuth',
   MonarchError = 'monarchError',
   NoMonarchTransactions = 'noMonarchTransactions',
@@ -25,11 +25,11 @@ export enum FailureReason {
 
 export const mapFailureReasonToMessage = (reason: FailureReason | undefined): string => {
   switch (reason) {
-    case FailureReason.NoAmazonOrders:
+    case FailureReason.NoProviderOrders:
       return 'No Amazon orders found';
-    case FailureReason.NoAmazonAuth:
+    case FailureReason.NoProviderAuth:
       return 'Amazon authorization failed';
-    case FailureReason.AmazonError:
+    case FailureReason.ProviderError:
       return 'An error occurred while fetching Amazon orders';
     case FailureReason.NoMonarchAuth:
       return 'Monarch authorization failed';
@@ -52,10 +52,13 @@ export type LastSync = {
   dryRun?: boolean;
 };
 
-type Options = {
+export type Options = {
   overrideTransactions: boolean;
   amazonMerchant: string;
+  walmartMerchant: string;
   syncEnabled: boolean;
+  transactionMatchingWindowInDays: number;
+  maxPages: number | undefined;
 };
 
 type State = {
@@ -84,7 +87,10 @@ const appStorage = createStorage<State>(
     options: {
       overrideTransactions: false,
       amazonMerchant: 'Amazon',
+      walmartMerchant: 'Walmart',
       syncEnabled: false,
+      transactionMatchingWindowInDays: 7,
+      maxPages: Infinity,
     },
   },
   {

--- a/src/shared/storages/debugStorage.ts
+++ b/src/shared/storages/debugStorage.ts
@@ -27,6 +27,7 @@ export async function debugLog(val: unknown) {
   await debugStorage.set(state => ({
     logs: (state?.logs ?? []).concat([stringValue]),
   }));
+  console.log(val);
 }
 
 export default debugStorage;

--- a/src/shared/storages/progressStorage.ts
+++ b/src/shared/storages/progressStorage.ts
@@ -4,6 +4,8 @@ export enum ProgressPhase {
   Idle = 'idle',
   AmazonPageScan = 'amazon_page_scan',
   AmazonOrderDownload = 'amazon_order_download',
+  WalmartPageScan = 'walmart_page_scan',
+  WalmartOrderDownload = 'walmart_order_download',
   MonarchDownload = 'monarch_download',
   MonarchUpload = 'monarch_upload',
   Complete = 'complete',


### PR DESCRIPTION
- [x] Works side by side with Amazon
- [x] Fetches the first page of orders
- [ ] Fetches all pages of orders
- [ ] Separate wording for Amazon and Walmart (distinguish which one is syncing now, which one errored out, etc)
- [ ] At least one of Amazon and Walmart need a session - not both 
- [ ] Walmart connection indicator
- [ ] Amazon and Walmart implement a Provider interface

Those interested in using my modified version should check out `nowaker` branch on my fork for finished changes, and `walmart` branch for this WIP feature. https://github.com/nowaker/monarch-amazon-sync