### PR TITLE
[Bug fix] If an item doesn't have a price, making the price fixed throws a fatal error

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -246,6 +246,13 @@ async function updateMonarchTransactions() {
 
   for (const data of matches) {
     const itemString = data.items
+      .filter(item => {
+        if (!item.price) {
+          debugLog(`item ${item.title} has an unknown price.`);
+          return false;
+        }
+        return true;
+      })
       .map(item => {
         return item.quantity + 'x ' + item.title + ' - $' + item.price.toFixed(2);
       })


### PR DESCRIPTION
Console error:
```
index.js:33 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'toFixed')
at index.js:33:4023
at Array.map (<anonymous>)
at ge (index.js:33:3977)
at async K (index.js:33:2036)
index.js:89 Uncaught (in promise) Error: A listener indicated an asynchronous response by returning true, 
but the message channel closed before a response was received
```

In my situation this was caused by grocery items that for some reason don't have a price. I chose to omit it, but maybe the better option is listing it without price. Happy to hear feedback!